### PR TITLE
Rename ERC1155s to ERC1155A

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ERC-1155s - SuperForm's ERC-1155 Extension
+# ERC1155A - SuperForm's ERC-1155 Extension
 
 SuperForm implementation of ERC-1155 with extended approval logic. Allows token owners to execute single id approvals in place of mass approving all of the ERC-1155 ids to the spender.
 
@@ -8,7 +8,7 @@ You need foundry/forge to run repository.
 
 `forge test`
 
-Two set of tests are run. `ERC-1155s` specific and general `ERC-1155` tests forked from solmate's implementation of the standard. SuperForm's `ERC-1155s` has exactly the same interface as standard `ERC-1155` and expected behavior of functions follow EIP documentation.
+Two set of tests are run. `ERC1155A` specific and general `ERC1155` tests forked from solmate's implementation of the standard. SuperForm's `ERC1155A` has exactly the same interface as standard `ERC1155` and expected behavior of functions follow EIP documentation.
 
 # Rationale
 
@@ -16,9 +16,9 @@ ERC1155 `setApprovalForAll` function gives full spending permissions over all cu
 
 # Implementation Details
 
-Main change is how `ERC-1155s` implements `safeTransferFrom()` function. Standard ERC-115 implementations are checking only if caller `isApprovedForAll` or an owner of token ids. We propose `setApprovalForOne()` function allowing approvals for specific id in any amount. Therefore, id owner is no longer required to mass approve all of his token ids. The side effect of it is requirement of additional validation logic inside of `safeTransferFrom()` function.
+Main change is how `ERC1155A` implements `safeTransferFrom()` function. Standard ERC-1155 implementations are checking only if caller `isApprovedForAll` or an owner of token ids. We propose `setApprovalForOne()` function allowing approvals for specific id in any amount. Therefore, id owner is no longer required to mass approve all of his token ids. The side effect of it is requirement of additional validation logic inside of `safeTransferFrom()` function.
 
-With gas effiency in mind and preservation of expected ERC-1155 behavior, ERC-1155s still prioritizes `isApprovedForAll` over `setApprovalForOne()`. Only `safeTransferFrom()` function works with single allowances, `safeBatchTransferFrom()` function requires owner to grant `setApprovalForAll()` to the operator. Decision is dictated by a significant gas costs overhead when required to decrease (or reset, in case of an overflow) allowances for each id in array. Moreover, if owner has `setApprovalForAll()` set to `true`, ERC-1155s contract will not modify existing single allowances during `safeTransferFrom()` and `safeBatchTransferFrom()` - assuming that owner has full trust in _operator_ for granting mass approve. Therefore, ERC-1155s requires owners to manage their allowances individually and be mindfull of enabling `setApprovalForAll()` for external contracts.
+With gas effiency in mind and preservation of expected ERC1155 behavior, ERC1155A still prioritizes `isApprovedForAll` over `setApprovalForOne()`. Only `safeTransferFrom()` function works with single allowances, `safeBatchTransferFrom()` function requires owner to grant `setApprovalForAll()` to the operator. Decision is dictated by a significant gas costs overhead when required to decrease (or reset, in case of an overflow) allowances for each id in array. Moreover, if owner has `setApprovalForAll()` set to `true`, ERC1155A contract will not modify existing single allowances during `safeTransferFrom()` and `safeBatchTransferFrom()` - assuming that owner has full trust in _operator_ for granting mass approve. Therefore, ERC1155A requires owners to manage their allowances individually and be mindfull of enabling `setApprovalForAll()` for external contracts.
 
 # Allowances Flow of Execution
 
@@ -44,7 +44,7 @@ If caller only approvedForAll, function executes without reducing allowance (ful
 
 Additional approval logic validation makes SOME transfer operations more expensive. Here's how it looks by comparison to solmate ERC1155 standard implementation:
 
-ERC-1155S
+ERC1155A
 
 ```
 | safeBatchTransferFrom                            | 79432           | 79432 | 79432  | 79432 | 1       |

--- a/src/ERC1155A.sol
+++ b/src/ERC1155A.sol
@@ -1,12 +1,12 @@
 /// SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.19;
 
-import {IERC1155s} from "./interfaces/IERC1155s.sol";
+import {IERC1155A} from "./interfaces/IERC1155A.sol";
 import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 
 /**
- * @title ERC1155S
- * @dev ERC1155S is a SuperForm specific extension for ERC1155.
+ * @title ERC1155A
+ * @dev ERC1155A is a proposed extension for ERC1155.
  * @dev Adapted solmate implementation, follows ERC1155 standard interface
  *
  * 1. Single id approve capability
@@ -15,7 +15,7 @@ import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
  *
  */
 
-abstract contract ERC1155s is IERC1155s {
+abstract contract ERC1155A is IERC1155A {
     /*//////////////////////////////////////////////////////////////
                              ERC1155s STORAGE
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/IERC1155A.sol
+++ b/src/interfaces/IERC1155A.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import {IERC1155} from "openzeppelin-contracts/contracts/token/ERC1155/IERC1155.sol";
 
-interface IERC1155s is IERC1155 {
+interface IERC1155A is IERC1155 {
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/ITransmuter.sol
+++ b/src/interfaces/ITransmuter.sol
@@ -17,9 +17,9 @@ interface ITransmuter {
     ) external returns (address);
 
     /// @notice Use ERC1155 BatchTransfer to transmute multiple ERC1155 ids into separate ERC20
-    /// Easier to transmute to 1155s than to transmute back to erc20 because of ERC1155 beauty!
-    /// @param ids ids of the ERC1155s to transmute
-    /// @param amounts amounts of the ERC1155s to transmute
+    /// Easier to transmute to 1155A than to transmute back to erc20 because of ERC1155 beauty!
+    /// @param ids ids of the ERC1155A to transmute
+    /// @param amounts amounts of the ERC1155A to transmute
     function transmuteBatchToERC20(uint256[] memory ids, uint256[] memory amounts) external;
 
     /// @param id id of the ERC20s to transmute to erc20
@@ -28,5 +28,5 @@ interface ITransmuter {
 
     /// @param id id of the ERC20s to transmute to erc1155
     /// @param amount amount of the ERC20s to transmute to erc1155
-    function transmuteToERC1155s(uint256 id, uint256 amount) external;
+    function transmuteToERC1155A(uint256 id, uint256 amount) external;
 }

--- a/src/test/ERC1155.t.sol
+++ b/src/test/ERC1155.t.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.19;
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {DSInvariantTest} from "solmate/test/utils/DSInvariantTest.sol";
 import {ERC1155TokenReceiver} from "solmate/tokens/ERC1155.sol";
-import {MockERC1155s} from "./mocks/MockERC1155s.sol";
+import {MockERC1155A} from "./mocks/MockERC1155A.sol";
 
 /**
- * @title ERC1155 Test Suite from Solmate re-adapted for ERC1155-S
+ * @title ERC1155 Test Suite from Solmate re-adapted for ERC1155A
  * @dev We preserve full expected functionality of ERC1155
  * original by @author - solmate
  * forked by @author - ZeroPointLabs
@@ -114,13 +114,13 @@ contract WrongReturnDataERC1155Recipient is ERC1155TokenReceiver {
 contract NonERC1155Recipient {}
 
 contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
-    MockERC1155s token;
+    MockERC1155A token;
 
     mapping(address => mapping(uint256 => uint256)) public userMintAmounts;
     mapping(address => mapping(uint256 => uint256)) public userTransferOrBurnAmounts;
 
     function setUp() public {
-        token = new MockERC1155s();
+        token = new MockERC1155A();
     }
 
     function testMintToEOA() public {

--- a/src/test/ERC1155_A.t.sol
+++ b/src/test/ERC1155_A.t.sol
@@ -2,20 +2,20 @@
 pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
-import {MockERC1155s} from "./mocks/MockERC1155s.sol";
+import {MockERC1155A} from "./mocks/MockERC1155A.sol";
 
-contract ERC1155STest is Test {
-    MockERC1155s public SuperShares;
+contract ERC1155ATest is Test {
+    MockERC1155A public SuperShares;
     uint256 public constant THOUSAND_E18 = 1000 ether;
     address public alice = address(0x2137);
     address public bob = address(0x0997);
 
     function setUp() public {
-        SuperShares = new MockERC1155s();
+        SuperShares = new MockERC1155A();
         SuperShares.mint(alice, 1, THOUSAND_E18, "");
     }
 
-    /// @dev All possible approval combinations for ERC1155S
+    /// @dev All possible approval combinations for ERC1155A
     /// Case 1: AllApproval + NO SingleApproval (standard 1155)
     /// Case 2: AllApproval + SingleApproval (AllApproved tokens decrease SingleApprove too)
     /// Case 3: SingleApproval + NO AllApproval (decrease SingleApprove allowance)

--- a/src/test/Transmuter.t.sol
+++ b/src/test/Transmuter.t.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 import {Transmuter} from "../transmuter/Transmuter.sol";
-import {MockERC1155s} from "./mocks/MockERC1155s.sol";
+import {MockERC1155A} from "./mocks/MockERC1155A.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {sERC20} from "../transmuter/sERC20.sol";
 
 contract TransmuterTest is Test {
     uint256 public constant THOUSAND_E18 = 1000 ether;
 
-    MockERC1155s public superPositions;
+    MockERC1155A public superPositions;
     Transmuter public transmuter;
     ERC20 public syntheticERC20Token;
 
@@ -18,7 +18,7 @@ contract TransmuterTest is Test {
     address public bob = address(0x0997);
 
     function setUp() public {
-        superPositions = new MockERC1155s();
+        superPositions = new MockERC1155A();
         superPositions.mint(alice, 1, THOUSAND_E18, "");
 
         transmuter = new Transmuter(superPositions);
@@ -41,7 +41,7 @@ contract TransmuterTest is Test {
         syntheticERC20Token.approve(address(transmuter), sERC20Balance);
 
         /// NOTE: Test if 1:1 between 1155 and 20 always holds
-        transmuter.transmuteToERC1155s(1, sERC20Balance);
+        transmuter.transmuteToERC1155A(1, sERC20Balance);
 
         assertEq(superPositions.balanceOf(alice, 1), THOUSAND_E18);
 

--- a/src/test/mocks/MockERC1155A.sol
+++ b/src/test/mocks/MockERC1155A.sol
@@ -1,12 +1,12 @@
 /// SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.19;
 
-import {ERC1155s} from "../../ERC1155s.sol";
+import {ERC1155A} from "../../ERC1155A.sol";
 import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 
-/// @notice For test purpouses we open mint()/burn() functions of ERC1155s
-contract MockERC1155s is ERC1155s {
-    /// @dev See ../ERC1155s.sol
+/// @notice For test purpouses we open mint()/burn() functions of ERC1155A
+contract MockERC1155A is ERC1155A {
+    /// @dev See ../ERC1155A.sol
     function uri(uint256 superFormId) public pure override returns (string memory) {
         return string(abi.encodePacked(_baseURI(), Strings.toString(superFormId)));
     }

--- a/src/transmuter/Transmuter.sol
+++ b/src/transmuter/Transmuter.sol
@@ -1,26 +1,26 @@
 /// SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.19;
 
-import {IERC1155s} from "../interfaces/IERC1155s.sol";
+import {IERC1155A} from "../interfaces/IERC1155A.sol";
 import {sERC20} from "./sERC20.sol";
 import {ITransmuter} from "../interfaces/ITransmuter.sol";
 
 /// @title Transmuter
 /// @author Zeropoint Labs.
-/// @dev allows users to transmute all or individual ids of ERC1155s into synthetic ERC20s
+/// @dev allows users to transmute all or individual ids of ERC1155A into synthetic ERC20s
 contract Transmuter is ITransmuter {
-    IERC1155s public immutable sERC1155;
+    IERC1155A public immutable sERC1155;
 
     event TransmutedToERC20(address user, uint256 id, uint256 amount);
     event TransmutedBatchToERC20(address user, uint256[] ids, uint256[] amounts);
-    event TransmutedToERC1155s(address user, uint256 id, uint256 amount);
+    event TransmutedToERC1155A(address user, uint256 id, uint256 amount);
 
     error TRANSMUTER_ALREADY_REGISTERED();
 
     mapping(uint256 id => address syntheticToken) public synthethicTokenId;
 
-    constructor(IERC1155s erc1155s) {
-        sERC1155 = erc1155s;
+    constructor(IERC1155A erc1155A) {
+        sERC1155 = erc1155A;
     }
 
     /// @inheritdoc ITransmuter
@@ -74,7 +74,7 @@ contract Transmuter is ITransmuter {
     }
 
     /// @inheritdoc ITransmuter
-    function transmuteToERC1155s(uint256 id, uint256 amount) external override {
+    function transmuteToERC1155A(uint256 id, uint256 amount) external override {
         sERC20 token = sERC20(synthethicTokenId[id]);
 
         /// @dev No need to transfer to contract, we can burn for msg.sender
@@ -88,7 +88,7 @@ contract Transmuter is ITransmuter {
 
         sERC1155.safeBatchTransferFrom(address(this), msg.sender, ids, amounts, bytes(""));
 
-        emit TransmutedToERC1155s(msg.sender, id, amount);
+        emit TransmutedToERC1155A(msg.sender, id, amount);
     }
 
     /*///////////////////////////////////////////////////////////////


### PR DESCRIPTION
After merging, can change repo name too. Will probably need to run through the readme again before launch. 